### PR TITLE
Client improvements

### DIFF
--- a/api/memetrics/events/schemas.py
+++ b/api/memetrics/events/schemas.py
@@ -4,9 +4,23 @@ from typing import Any, Literal, TypedDict
 from bson import ObjectId
 from pydantic import BaseModel, Field, validator
 from pymongo import IndexModel
-from tauth.schemas import Creator
 
-from ..utils import PyObjectId
+try:
+    from tauth.schemas import Creator
+except:
+    from pydantic import EmailStr
+
+    class Creator(BaseModel):
+        client_name: str
+        token_name: str
+        user_email: EmailStr
+        user_ip: str = "127.0.0.1"
+
+
+try:
+    from ..utils import PyObjectId
+except:
+    from ruson import PydanticObjectId as PyObjectId
 
 
 class Attribute(BaseModel):
@@ -60,7 +74,11 @@ class EventData(BaseModel):
                     "app_version": "1.2.3",
                     "extra": [
                         {"name": "message-id", "type": "string", "value": "123"},
-                        {"name": "user-agent", "type": "string", "value": "firefox-116"},
+                        {
+                            "name": "user-agent",
+                            "type": "string",
+                            "value": "firefox-116",
+                        },
                     ],
                     "type": "chat.thread.message.code-block",
                     "user": {

--- a/py-sdk/memetrics_sdk/async_webservice.py
+++ b/py-sdk/memetrics_sdk/async_webservice.py
@@ -18,6 +18,12 @@ class AsyncWebserviceClient:
         url: str = os.environ.get("MEMETRICS_URL"),
         api_key: str = os.environ.get("TEIA_API_KEY"),
     ):
+        if url is None:
+            raise ValueError("URL not defined.")
+
+        if api_key is None:
+            raise ValueError("API Key not defined.")
+
         self.api_key = api_key
         self.url = url
         self.headers = {

--- a/py-sdk/memetrics_sdk/async_webservice.py
+++ b/py-sdk/memetrics_sdk/async_webservice.py
@@ -15,8 +15,8 @@ class AsyncWebserviceClient:
     def __init__(
         self,
         timeout: float = 0.5,
-        url: str = os.environ["MEMETRICS_URL"],
-        api_key: str = os.environ["TEIA_API_KEY"],
+        url: str = os.environ.get("MEMETRICS_URL"),
+        api_key: str = os.environ.get("TEIA_API_KEY"),
     ):
         self.api_key = api_key
         self.url = url

--- a/py-sdk/memetrics_sdk/async_webservice.py
+++ b/py-sdk/memetrics_sdk/async_webservice.py
@@ -12,9 +12,14 @@ from .schemas import TAuthHeaders
 
 
 class AsyncWebserviceClient:
-    def __init__(self, timeout: float = 0.5):
-        self.api_key = os.environ["TEIA_API_KEY"]
-        self.url = os.environ["MEMETRICS_URL"]
+    def __init__(
+        self,
+        timeout: float = 0.5,
+        url: str = os.environ["MEMETRICS_URL"],
+        api_key: str = os.environ["TEIA_API_KEY"],
+    ):
+        self.api_key = api_key
+        self.url = url
         self.headers = {
             "Authorization": f"Bearer {self.api_key}",
         }

--- a/py-sdk/memetrics_sdk/webservice.py
+++ b/py-sdk/memetrics_sdk/webservice.py
@@ -12,9 +12,15 @@ from .schemas import EventData, TAuthHeaders
 class WebserviceClient:
     def __init__(
         self,
-        url: str = os.environ["MEMETRICS_URL"],
-        api_key: str = os.environ["TEIA_API_KEY"],
+        url: str = os.environ.get("MEMETRICS_URL"),
+        api_key: str = os.environ.get("TEIA_API_KEY"),
     ):
+        if url is None:
+            raise ValueError("URL not defined.")
+
+        if api_key is None:
+            raise ValueError("API Key not defined.")
+
         self.api_key = api_key
         self.url = url
         self.headers = {

--- a/py-sdk/memetrics_sdk/webservice.py
+++ b/py-sdk/memetrics_sdk/webservice.py
@@ -1,13 +1,12 @@
-import os
 import json
+import os
 from datetime import datetime
-
 from typing import Optional, cast
 
 import httpx
 from memetrics.events.schemas import GeneratedFields
 
-from .schemas import TAuthHeaders, EventData
+from .schemas import EventData, TAuthHeaders
 
 
 class WebserviceClient:

--- a/py-sdk/memetrics_sdk/webservice.py
+++ b/py-sdk/memetrics_sdk/webservice.py
@@ -11,9 +11,13 @@ from .schemas import TAuthHeaders, EventData
 
 
 class WebserviceClient:
-    def __init__(self):
-        self.api_key = os.environ["TEIA_API_KEY"]
-        self.url = os.environ["MEMETRICS_URL"]
+    def __init__(
+        self,
+        url: str = os.environ["MEMETRICS_URL"],
+        api_key: str = os.environ["TEIA_API_KEY"],
+    ):
+        self.api_key = api_key
+        self.url = url
         self.headers = {
             "Authorization": f"Bearer {self.api_key}",
         }


### PR DESCRIPTION
- Allow API Key and URL to be passed through arguments
- Organize imports
- Allow API Key and URL to be passed through arguments for async client
- Add insert one to directly call memetrics API
